### PR TITLE
Scripts for Align and Move to Canvas Center

### DIFF
--- a/plugins/src/Nudge/Nudge.lua
+++ b/plugins/src/Nudge/Nudge.lua
@@ -1,5 +1,8 @@
 ---------------------------------------------------------------
 -- Nudge
+--
+-- author: quietly-turning
+-- github: https://github.com/quietly-turning/
 ---------------------------------------------------------------
 
 init = function(plugin)

--- a/scripts/Align.lua
+++ b/scripts/Align.lua
@@ -1,0 +1,275 @@
+---------------------------------------------------------------
+-- Align Layers
+--
+-- Call this script when one or more Layers is selected and the
+-- pixel contents of each layer will be aligned to canvas center.
+--
+-- From there, you can use the Dialog to change the horizontal and
+-- vertical alignment of both:
+--   • the layers you are aligning
+--   • what part of the canvas you are aligning them to
+--
+-- author: quietly-turning
+-- github: https://github.com/quietly-turning/
+---------------------------------------------------------------
+
+
+---------------------------------------------------------------
+-- helper function
+
+local Clamp = function(val, low, high)
+	if val < low  then return low  end
+	if val > high then return high end
+	return val
+end
+
+
+---------------------------------------------------------------
+-- variables that need scope over the entire file
+
+-- alignA, used for the thing we are aligning
+-- alignB, used for the thing we are aligning alignA to
+-- both tables are { horizontal, vertical } where
+--   horizontal is a value from 0 (left) to 1 (right)
+--   vertical   is a value from 0 (top)  to 1 (bottom)
+--                h    v
+local alignA = { 0.5, 0.5 }
+local alignB = { 0.5, 0.5 }
+
+
+local Align = function()
+
+	---------------------------------------------------------------
+	-- basic validation; exit early if conditions aren't right
+	---------------------------------------------------------------
+
+	-- ensure that at least 1 layer is active
+	if #app.range.layers <= 0 then
+		-- return early; there's nothing more we can do
+		print("No layers are currently selected.")
+		return
+	end
+
+	---------------------------------------------------------------
+	-- variables that need to be declared prior to helper functions
+	---------------------------------------------------------------
+
+	local layers = {}
+
+	local alignpoint
+	local spr = app.activeSprite
+
+	---------------------------------------------------------------
+	-- helper functions
+	---------------------------------------------------------------
+
+	local FindInTable = function(needle, haystack)
+		for i,v in ipairs(haystack) do
+			if needle == v then return i end
+		end
+		return false
+	end
+
+	-- declare variable to be used as a function called recursively
+	-- it needs to be declared separately from assignment for recursion to work
+	local TraverseLayers
+
+	TraverseLayers = function(_layers, BaseCaseFunc)
+		for _, layer in ipairs(_layers) do
+			if not FindInTable(layer, layers) then
+				-- if this layer has sub-layers, it's a group
+				-- recurse; continue traversing those sub-layers
+				if layer.layers then
+					TraverseLayers(layer.layers, BaseCaseFunc)
+
+				-- if not, it has Cels
+				-- base case; no futher children to recurse through
+				else
+					BaseCaseFunc(layer)
+				end
+			end
+		end
+	end
+
+	---------------------------------------------------------------
+	-- main logic
+	---------------------------------------------------------------
+
+	-- ---------------
+	-- step 1: get array of layers
+
+	TraverseLayers(app.range.layers, function(layer) table.insert(layers, layer) end)
+
+
+	-- ---------------
+	-- step 2: align
+
+	local CalculateAlignPoint = function()
+		if spr then
+			alignpoint = {
+				x = math.floor(spr.spec.width  * Clamp(alignB[2], 0, 1)),
+				y = math.floor(spr.spec.height * Clamp(alignB[1], 0, 1))
+			}
+		end
+
+		-- fallback values just in case
+		if alignpoint == nil then
+			print("No alignment point could be detected.\nFalling back on {0,0}")
+			alignpoint = { x=0, y=0 }
+		end
+	end
+
+
+	local AlignCelsInLayer = function(layer)
+
+		-- update alignpoint now in case the user has changed it
+		CalculateAlignPoint()
+
+		-- loop through all Cels in this layer
+		-- the "cel" variable will be a reference to the Aseprite Cel at index "i"
+		--     "cel" will have its own properties that we can do things with
+		for i, cel in ipairs(layer.cels) do
+			-- modify this cel's x and y position
+			cel.position = {
+				x = alignpoint.x - (cel.bounds.width  * Clamp(alignA[2], 0, 1)),
+				y = alignpoint.y - (cel.bounds.height * Clamp(alignA[1], 0, 1))
+			}
+		end
+	end
+
+
+	-- loop through layers comparing all Cels in each to find the largest Cel
+	for _, layer in ipairs(layers) do AlignCelsInLayer(layer) end
+
+	app.refresh()
+end
+
+
+---------------------------------------------------------------
+-- code for the Dialog the user will see and interact with
+
+local dlg = Dialog("Align")
+
+
+dlg:label({text="selection alignment"})
+:newrow()
+
+-- alignA, the thing we are aligning
+-- the alignA variable
+:radio({
+	id="alignA_topleft",
+	selected=false,
+	onclick=function() alignA = { 0, 0 }; app.transaction( Align ) end
+})
+:radio({
+	id="alignA_topcenter",
+	selected=false,
+	onclick=function() alignA = { 0, 0.5 }; app.transaction( Align ) end
+})
+:radio({
+	id="alignA_topright",
+	selected=false,
+	onclick=function() alignA = { 0, 1 }; app.transaction( Align ) end
+})
+:newrow()
+:radio({
+	id="alignA_middleleft",
+	selected=false,
+	onclick=function() alignA = { 0.5, 0 }; app.transaction( Align ) end
+})
+:radio({
+	id="alignA_middlecenter",
+	selected=true,
+	onclick=function() alignA = { 0.5, 0.5 }; app.transaction( Align ) end
+})
+:radio({
+	id="alignA_middleright",
+	selected=false,
+	onclick=function() alignA = { 0.5, 1 }; app.transaction( Align ) end
+})
+:newrow()
+:radio({
+	id="alignA_bottomleft",
+	selected=false,
+	onclick=function() alignA = { 1, 0 }; app.transaction( Align ) end
+})
+:radio({
+	id="alignA_bottomcenter",
+	selected=false,
+	onclick=function() alignA = { 1, 0.5 }; app.transaction( Align ) end
+})
+:radio({
+	id="alignA_bottomright",
+	selected=false,
+	onclick=function() alignA = { 1, 1 }; app.transaction( Align ) end
+})
+
+:separator()
+
+-- alignB, the thing we are aligning alignA to
+:label({text="align to"})
+:newrow()
+
+
+:radio({
+	-- it's not documented anywhere I found
+	-- but Aesprite's API for dialogs/widgets
+	-- will only(?) start a new group of radio
+	-- buttons when a label is encountered
+	label="",
+
+	id="alignB_topleft",
+	selected=false,
+	onclick=function() alignB = { 0, 0 } ; app.transaction( Align )end,
+})
+:radio({
+	id="alignB_topcenter",
+	selected=false,
+	onclick=function() alignB = { 0, 0.5 }; app.transaction( Align ) end
+})
+:radio({
+	id="alignB_topright",
+	selected=false,
+	onclick=function() alignB = { 0, 1 }; app.transaction( Align ) end
+})
+:newrow()
+:radio({
+	id="alignB_middleleft",
+	selected=false,
+	onclick=function() alignB = { 0.5, 0 }; app.transaction( Align ) end
+})
+:radio({
+	id="alignB_middlecenter",
+	selected=true,
+	onclick=function() alignB = { 0.5, 0.5 }; app.transaction( Align ) end
+})
+:radio({
+	id="alignB_middleright",
+	selected=false,
+	onclick=function() alignB = { 0.5, 1 }; app.transaction( Align ) end
+})
+:newrow()
+:radio({
+	id="alignB_bottomleft",
+	selected=false,
+	onclick=function() alignB = { 1, 0 }; app.transaction( Align ) end
+})
+:radio({
+	id="alignB_bottomcenter",
+	selected=false,
+	onclick=function() alignB = { 1, 0.5 }; app.transaction( Align ) end
+})
+:radio({
+	id="alignB_bottomright",
+	selected=false,
+	onclick=function() alignB = { 1, 1 }; app.transaction( Align ) end
+})
+
+
+-- allow the user to continue to interact with Aseprite while this dialog is up
+dlg:show({wait=false})
+
+---------------------------------------------------------------
+-- perform an align now, immediately when the dialog is first seen by the user
+-- all layers will be centered to canvas center
+app.transaction( Align )

--- a/scripts/Fade In-Out.lua
+++ b/scripts/Fade In-Out.lua
@@ -1,10 +1,12 @@
 ---------------------------------------------------------------
 -- Fade In/Out
 --
--- Call this script when a single Cel is selected and you'll be
+-- Call this script when a single Layer or Cel is selected and you'll be
 -- prompted for:
 --  • a quantity of frames (number input)
 --  • whether you want to fadeIn or fadeOut (button press)
+--
+-- Note that this only operates on a single Layer at a time.
 --
 -- author: quietly-turning
 -- github: https://github.com/quietly-turning/
@@ -30,20 +32,26 @@ local end_opacity   = nil
 ---------------------------------------------------------------
 
 local Check = function(frame_count)
-	local msg
+	local errors = {}
 
-	if not app.activeLayer then msg = "You need to have an activeLayer." end
-	if not app.activeCel   then msg = "You need to have an activeCel." end
-	if not type(start_frame)=="number" then msg = "Please provide a value for Frames." end
+	if not app.activeLayer then errors[#errors+1] = "You need to have an activeLayer." end
+	if not app.activeCel   then errors[#errors+1] = "You need to have an activeCel." end
 
-	return msg
+	return errors
 end
 
 local ApplyFade = function()
 	local frame_count = dlg.data.frame_count
 
-	local error = Check(frame_count)
-	if error then print(error); return end
+	local errors = Check(frame_count)
+	-- if there were errors
+	if #errors > 0 then
+		-- print them
+		for _,msg in ipairs(errors) do print(msg) end
+		-- and return early from ApplyFade()
+	 	return
+	end
+
 
 	local start_frame = app.activeCel.frameNumber or 1
 
@@ -93,4 +101,5 @@ dlg:button({
 	end
 })
 
+-- allow the user to continue to interact with Aseprite while this dialog is up
 dlg:show({wait=false})

--- a/scripts/Move to Canvas Center.lua
+++ b/scripts/Move to Canvas Center.lua
@@ -1,0 +1,170 @@
+---------------------------------------------------------------
+-- Move to Canvas Center
+--
+-- author: quietly-turning
+-- github: https://github.com/quietly-turning/
+---------------------------------------------------------------
+
+local MoveToCenter = function()
+
+	---------------------------------------------------------------
+	-- basic validation; exit early if conditions aren't right
+	---------------------------------------------------------------
+
+	-- ensure that at least 1 layer is active
+	if #app.range.layers <= 0 then
+		-- return early; there's nothing more we can do
+		print("No layers are currently selected.")
+		return
+	end
+
+	---------------------------------------------------------------
+	-- initialization
+	---------------------------------------------------------------
+
+	local canvas_center_point
+	local spr = app.activeSprite
+
+	if spr then
+		canvas_center_point = Point({
+			x = spr.spec.width  // 2,
+			y = spr.spec.height // 2,
+		})
+	end
+
+	-- fallback values just in case
+	if canvas_center_point == nil then
+		print("The canvas center could not be detected.\nMoving to {0,0} instead.")
+		canvas_center_point = Point({x=0, y=0})
+	end
+
+	local layers = {}
+
+	---------------------------------------------------------------
+	-- helper functions
+	---------------------------------------------------------------
+
+	local FindInTable = function(needle, haystack)
+		for i,v in ipairs(haystack) do
+			if needle == v then return i end
+		end
+		return false
+	end
+
+
+	-- declare variable to be used as a function called recursively
+	-- it needs to be declared separately from assignment for recursion to work
+	local TraverseLayers
+
+	TraverseLayers = function(_layers, BaseCaseFunc)
+		for _, layer in ipairs(_layers) do
+			if not FindInTable(layer, layers) then
+				-- if this layer has sub-layers, it's a group
+				-- recurse; continue traversing those sub-layers
+				if layer.layers then
+					TraverseLayers(layer.layers, BaseCaseFunc)
+
+				-- if not, it has Cels
+				-- base case; no futher children to recurse through
+				else
+					BaseCaseFunc(layer)
+				end
+			end
+		end
+	end
+
+	---------------------------------------------------------------
+	-- main logic
+	---------------------------------------------------------------
+	-- moving a collection of layers to canvas center involves three steps:
+	--
+	-- 1. get an array of layers to process
+	--      ideally, this is all selected layers, but the user may have a single
+	--      "group" layer selected, and expects all children layers to be moved
+	--
+	-- 2. find the largest single cel
+	--      we want to maintain each layer's cels' relative positioning to
+	--      one another when moving
+	--
+	--      to do that, we need to find the largest single cel in the set of layers
+	--      from step 1, calculate its distance from canvas center, and then move
+	--      every cel to canvas center relative to it.
+	--
+	--      so, step 2 is to find the largest cel
+	--
+	-- 3. loop through each cel in each layer and move it
+
+
+	-- ---------------
+	-- step 1: get array of layers
+
+	TraverseLayers(app.range.layers, function(layer) table.insert(layers, layer) end)
+
+
+	-- ---------------
+	-- step 2: find the largest single cel
+
+	local largestcel_rectangle = nil
+
+	local CompareCels = function(layer)
+		for i, cel in ipairs(layer.cels) do
+			if largestcel_rectangle == nil then
+				largestcel_rectangle = Rectangle(cel.bounds)
+
+			elseif (cel.bounds.width*cel.bounds.height) > (largestcel_rectangle.width*largestcel_rectangle.height) then
+				largestcel_rectangle = Rectangle({
+					x = cel.bounds.x,
+					y = cel.bounds.y,
+					width  = cel.image.width,
+					height = cel.image.height,
+				})
+			end
+		end
+	end
+
+	-- loop through layers comparing all Cels in each to find the largest Cel
+	for _, layer in ipairs(layers) do CompareCels(layer) end
+
+
+	-- ---------------
+	-- step 3. loop through each cel in each layer and move it
+
+	-- function used to loop through all cels in a layer and move them
+	-- relative to the largestcel_rectangle's centerpoint (which is itself centered relative to the canvas center)
+	local MoveCelsInLayer = function(layer)
+		-- loop through all Cels in this layer
+		for _, cel in ipairs(layer.cels) do
+			-- modify this cel's xy position
+			cel.position = {
+				x = (cel.bounds.x - largestcel_rectangle.x - (largestcel_rectangle.width  // 2)) + canvas_center_point.x,
+				y = (cel.bounds.y - largestcel_rectangle.y - (largestcel_rectangle.height // 2)) + canvas_center_point.y,
+			}
+		end
+	end
+
+	-- loop through layers and move each cel
+	for _, layer in ipairs(layers) do MoveCelsInLayer(layer) end
+end
+
+
+---------------------------------------------------------------
+
+-- transactions in asesprite are a way to group multiple actions
+-- into a single Undo.
+--
+-- In this script, we loop through all cels in the activeLayer
+-- and set the position of each as we go.  There would normally be
+-- 1 undo action for each position update.  If a layer had 100 frames,
+-- the user would need to tap control-Z (or command-Z) 100 times to
+-- to undo the effect of this script.
+--
+-- If we wrap everything the script does in a Lua function, and pass
+-- a reference to that function to app.transaction()
+-- all the effects of that function will be grouped together as a single Undo.
+--
+-- Note that for app.transaction to work properly, you must pass a reference
+-- to a function and not *call* a function.
+--
+-- So, this works because we're passing a reference to the MoveToCenter function itself,
+-- rather than the results of calling MoveToCenter()
+app.transaction( MoveToCenter )


### PR DESCRIPTION
# About

The scripts for *Align* and *Move to Canvas Center* should be ready for public use.

**Spec:** https://docs.google.com/document/d/14PKJugOGbCbjhWQKcKR0AGyruNwYQCKdViHlWYlUaYc/edit?usp=sharing

## Align

![align](https://user-images.githubusercontent.com/1253483/102489237-30265a00-403b-11eb-8ae4-3d9135d1614b.gif)

*Align* will act on either:

  * all selected layers, or
  * a group's children layers, if only the group is selected
  
This scripts will center layers to canvas-center as soon as the Dialog opens.   From there, the user can change the horizontal and vertical alignment of both the layers and where those layers are being aligned to using the Dialog.

## Move to Canvas Center

Similar to *Align*, this script will act on either all selected layers, or a group's children depending on what is currently selected.

This means that the user could center Flowery with all layers selected like this:
<img width="518" alt="CleanShot 2020-12-17 at 06 33 43@2x" src="https://user-images.githubusercontent.com/1253483/102489825-028de080-403c-11eb-82be-36204de78e38.png">

or with only the parent group selected, like this:
<img width="517" alt="CleanShot 2020-12-17 at 06 33 31@2x" src="https://user-images.githubusercontent.com/1253483/102489875-15a0b080-403c-11eb-969a-663edd3821cc.png">

The effect will be the same.  (The bug in older versions of this script where nested groups would be moved multiple times has been fixed.)

### Issues with *Move to Canvas Center*

This script compares each layer's bounding Rectangle, finds the rectangle with the largest area, and moves all layers relative to that.

A stray pixel accidentally added far away from the intended art will increase the size of layer's Rectangle and this throw off where the layers end up after being moved.  

<img width="1034" alt="CleanShot 2020-12-17 at 06 28 59@2x" src="https://user-images.githubusercontent.com/1253483/102490535-f7878000-403c-11eb-8279-c5d31a7a2ab1.png">

This script moves all the layers to canvas-center based on what it knows.  Flowery is technically "centered" in the screenshot above based on the width of the largest cel.

Unfortunately, **deleting these stray pixels does not update the Rectangle dimensions.**  This screenshot demonstrates that the bounding Rectangle for the *legs* layer is much wider than it should be, even though I've deleted the single stray pixel that appeared in a single cel.

The fix for this would be to find a way to update a layer's cel Rectangles before calling this script.