### PR TITLE
add script for Duplicate + Link Cels

### DIFF
--- a/scripts/Duplicate and Link Cels.lua
+++ b/scripts/Duplicate and Link Cels.lua
@@ -1,0 +1,45 @@
+---------------------------------------------------------------
+-- Duplicate and Link Cels
+--
+-- author: quietly-turning
+-- github: https://github.com/quietly-turning/
+---------------------------------------------------------------
+
+if not app then return end
+if not (app.isUIAvailable and app.activeCel) then return end
+if not app.range.type == RangeType.CELS then return end
+
+---------------------------------------------------------------
+
+local dlg = Dialog("Duplicate & Link")
+
+---------------------------------------------------------------
+
+local DupAndLink = function()
+	local frame_count = dlg.data.frame_count - 1
+
+	for i=1, frame_count do
+		app.command.NewFrame({content="cellinked"})
+	end
+
+	app.refresh()
+end
+
+---------------------------------------------------------------
+
+dlg:number({
+	id = "frame_count",
+	label = "Num Frames:",
+	text = "",
+	focus = true,
+})
+
+
+dlg:button({
+	id = "FadeOut_button",
+	text = "Duplicate",
+	onclick = function() app.transaction( DupAndLink ) end
+})
+
+-- allow the user to continue to interact with Aseprite while this dialog is up
+dlg:show({wait=false})


### PR DESCRIPTION
# Duplicate + Link Cels

I'd initially thought this wouldn't be possible because I didn't know where to look in the API.  Oops. 😅

There was a command `app.command.NewFrame({content="cellinked"})` that accomplished exactly what you were hoping for when I used it in a loop.

**Spec:** https://docs.google.com/document/d/1QzbbAVE_9DDyOVmwAvfBWMe4kB2HFt5wVHpFBeVuSAk/edit?usp=sharing

## Differences from Spec

The dialog looks like this:

<img width="246" alt="CleanShot 2020-12-17 at 12 51 26@2x" src="https://user-images.githubusercontent.com/1253483/102524215-a8eedb80-4066-11eb-87f0-6151a7046c91.png">

The original spec didn't include a button, suggesting the Dup+Link should automatically happen when the number was typed.  

There is an `onchange` event we could use, but if you wanted to duplicate and link `20` cels, you'd end up doing `2` and then `20` for a total of `22`.  I think a button is the only way around this, so that's what I've done here.